### PR TITLE
Update to Nix 2.23.1

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -16,6 +16,27 @@
         "type": "github"
       }
     },
+    "flake-parts": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1717285511,
+        "narHash": "sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "libgit2": {
       "flake": false,
       "locked": {
@@ -35,21 +56,23 @@
     "nix": {
       "inputs": {
         "flake-compat": "flake-compat",
+        "flake-parts": "flake-parts",
         "libgit2": "libgit2",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-regression": "nixpkgs-regression"
+        "nixpkgs-regression": "nixpkgs-regression",
+        "pre-commit-hooks": "pre-commit-hooks"
       },
       "locked": {
-        "lastModified": 1712161137,
-        "narHash": "sha256-ObaVDDPtnOeIE0t7m4OVk5G+OS6d9qYh+ktK67Fe/zE=",
-        "rev": "355cbc482f33f5b07a6bc0d72be862b1ccdb99dd",
-        "revCount": 16488,
+        "lastModified": 1719442162,
+        "narHash": "sha256-US+UsPhFeYoJH0ncjERRtVD1U20JtVtjsG+xhZqr/nY=",
+        "rev": "20ac7811904d5ee00d1d16ed811544c9d3297e15",
+        "revCount": 17394,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nix/2.21.2/018eaedc-df49-7da8-8007-06186938ee08/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nix/2.23.1/01905a9c-511f-7df0-910f-096ac5276124/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nix/%3D2.21.2"
+        "url": "https://flakehub.com/f/NixOS/nix/%3D2.23.1"
       }
     },
     "nixpkgs": {
@@ -96,6 +119,37 @@
       "original": {
         "type": "tarball",
         "url": "https://flakehub.com/f/NixOS/nixpkgs/%2A"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": [
+          "nix"
+        ],
+        "gitignore": [
+          "nix"
+        ],
+        "nixpkgs": [
+          "nix",
+          "nixpkgs"
+        ],
+        "nixpkgs-stable": [
+          "nix",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1719259945,
+        "narHash": "sha256-F1h+XIsGKT9TkGO3omxDLEb/9jOOsI6NnzsXFsZhry4=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -91,7 +91,7 @@
           settings = {
             always-allow-substitutes = true;
             bash-prompt-prefix = "(nix:$name)\\040";
-            experimental-features = [ "nix-command" "flakes" "repl-flake" ];
+            experimental-features = [ "nix-command" "flakes" ];
             extra-nix-path = [ "nixpkgs=flake:nixpkgs" ];
             upgrade-nix-store-path-url = "https://install.determinate.systems/nix-upgrade/stable/universal";
           };
@@ -119,7 +119,7 @@
           settings = {
             always-allow-substitutes = true;
             bash-prompt-prefix = "(nix:$name)\\040";
-            experimental-features = [ "nix-command" "flakes" "repl-flake" ];
+            experimental-features = [ "nix-command" "flakes" ];
             extra-nix-path = [ "nixpkgs=flake:nixpkgs" ];
             upgrade-nix-store-path-url = "https://install.determinate.systems/nix-upgrade/stable/universal";
           };
@@ -145,7 +145,7 @@
           settings = {
             always-allow-substitutes = true;
             bash-prompt-prefix = "(nix:$name)\\040";
-            experimental-features = [ "nix-command" "flakes" "repl-flake" ];
+            experimental-features = [ "nix-command" "flakes" ];
             extra-nix-path = [ "nixpkgs=flake:nixpkgs" ];
             upgrade-nix-store-path-url = "https://install.determinate.systems/nix-upgrade/stable/universal";
           };

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Determinate Nix";
   inputs = {
-    nix.url = "https://flakehub.com/f/NixOS/nix/=2.21.2";
+    nix.url = "https://flakehub.com/f/NixOS/nix/=2.23.1";
     nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/*";
   };
 


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nix':
    'https://api.flakehub.com/f/pinned/NixOS/nix/2.21.2/018eaedc-df49-7da8-8007-06186938ee08/source.tar.gz?narHash=sha256-ObaVDDPtnOeIE0t7m4OVk5G%2BOS6d9qYh%2BktK67Fe/zE%3D' (2024-04-03)
  → 'https://api.flakehub.com/f/pinned/NixOS/nix/2.23.1/01905a9c-511f-7df0-910f-096ac5276124/source.tar.gz?narHash=sha256-US%2BUsPhFeYoJH0ncjERRtVD1U20JtVtjsG%2BxhZqr/nY%3D' (2024-06-26)
• Added input 'nix/flake-parts':
    'github:hercules-ci/flake-parts/2a55567fcf15b1b1c7ed712a2c6fadaec7412ea8?narHash=sha256-iKzJcpdXih14qYVcZ9QC9XuZYnPc6T8YImb6dX166kw%3D' (2024-06-01)
• Added input 'nix/flake-parts/nixpkgs-lib':
    follows 'nix/nixpkgs'
• Added input 'nix/pre-commit-hooks':
    'github:cachix/pre-commit-hooks.nix/0ff4381bbb8f7a52ca4a851660fc7a437a4c6e07?narHash=sha256-F1h%2BXIsGKT9TkGO3omxDLEb/9jOOsI6NnzsXFsZhry4%3D' (2024-06-24)
• Added input 'nix/pre-commit-hooks/flake-compat':
    follows 'nix'
• Added input 'nix/pre-commit-hooks/gitignore':
    follows 'nix'
• Added input 'nix/pre-commit-hooks/nixpkgs':
    follows 'nix/nixpkgs'
• Added input 'nix/pre-commit-hooks/nixpkgs-stable':
    follows 'nix/nixpkgs'