### PR TITLE
Update to Nix 2.25.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,16 +96,16 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1732881227,
-        "narHash": "sha256-T+wFMm3cj8pGJSwXmPuxG5pz+1gRDJoToF9OBxtzocA=",
-        "rev": "218cd6c16c0981cc32a45e3a15be1d3c1a68eb85",
-        "revCount": 18724,
+        "lastModified": 1736783724,
+        "narHash": "sha256-cB/1vIYk8LWvL71hiKFu8froJHTUAfsYOOxBlBeNglI=",
+        "rev": "5b32a021a901d6d1dbde19cf0b26d1df5a36b518",
+        "revCount": 18801,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nix/2.25.3/01938786-bc70-79e3-b7ee-bb61f8e7f238/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nix/2.25.4/01946096-6202-736c-ba97-f7c4e454ac80/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nix/%3D2.25.3"
+        "url": "https://flakehub.com/f/NixOS/nix/%3D2.25.4"
       }
     },
     "nixpkgs": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Determinate Nix";
   inputs = {
-    nix.url = "https://flakehub.com/f/NixOS/nix/=2.25.3";
+    nix.url = "https://flakehub.com/f/NixOS/nix/=2.25.4";
     nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/*";
   };
 

--- a/flake.nix
+++ b/flake.nix
@@ -26,12 +26,12 @@
     in
     {
       closures = forAllSystems ({ system, ... }: nix.packages."${system}".default);
-      tarballs_indirect = forAllSystems ({ system, ... }: nix.checks."${system}".binaryTarball);
-      tarballs_direct = forAllSystems ({ system, ... }: "${nix.checks."${system}".binaryTarball}/nix-${nix.packages."${system}".default.version}-${system}.tar.xz");
+      tarballs_indirect = forAllSystems ({ system, ... }: nix.packages."${system}".binaryTarball);
+      tarballs_direct = forAllSystems ({ system, ... }: "${nix.packages."${system}".binaryTarball}/nix-${nix.packages."${system}".default.version}-${system}.tar.xz");
 
       checks = forAllSystems ({ system, ... }: {
         closure = nix.packages."${system}".default;
-        tarball = nix.checks."${system}".binaryTarball;
+        tarball = nix.packages."${system}".binaryTarball;
       });
 
       packages = forAllSystems ({ system, pkgs, ... }: {


### PR DESCRIPTION
Flake lock file updates:

• Updated input 'nix':
    'https://api.flakehub.com/f/pinned/NixOS/nix/2.25.3/01938786-bc70-79e3-b7ee-bb61f8e7f238/source.tar.gz?narHash=sha256-T%2BwFMm3cj8pGJSwXmPuxG5pz%2B1gRDJoToF9OBxtzocA%3D' (2024-11-29)
  → 'https://api.flakehub.com/f/pinned/NixOS/nix/2.25.4/01946096-6202-736c-ba97-f7c4e454ac80/source.tar.gz?narHash=sha256-cB/1vIYk8LWvL71hiKFu8froJHTUAfsYOOxBlBeNglI%3D' (2025-01-13)