### PR TITLE
Upgrade to Nix 2.25.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -96,16 +96,16 @@
         "nixpkgs-regression": "nixpkgs-regression"
       },
       "locked": {
-        "lastModified": 1732881227,
-        "narHash": "sha256-T+wFMm3cj8pGJSwXmPuxG5pz+1gRDJoToF9OBxtzocA=",
-        "rev": "218cd6c16c0981cc32a45e3a15be1d3c1a68eb85",
-        "revCount": 18724,
+        "lastModified": 1737397685,
+        "narHash": "sha256-9xrQhrqHCSqWsQveykZvG/ZMu0se66fUQw3xVSg6BpQ=",
+        "rev": "132c992ce04b809e0519e7d4521ab411cc80e52a",
+        "revCount": 18825,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nix/2.25.3/01938786-bc70-79e3-b7ee-bb61f8e7f238/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nix/2.25.5/01948d59-c05d-738f-89bd-468dc7e6d7cb/source.tar.gz"
       },
       "original": {
         "type": "tarball",
-        "url": "https://flakehub.com/f/NixOS/nix/%3D2.25.3"
+        "url": "https://flakehub.com/f/NixOS/nix/%3D2.25.5"
       }
     },
     "nixpkgs": {
@@ -158,12 +158,12 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1733120037,
-        "narHash": "sha256-En+gSoVJ3iQKPDU1FHrR6zIxSLXKjzKY+pnh9tt+Yts=",
-        "rev": "f9f0d5c5380be0a599b1fb54641fa99af8281539",
-        "revCount": 710194,
+        "lastModified": 1737404927,
+        "narHash": "sha256-e1WgPJpIYbOuokjgylcsuoEUCB4Jl2rQXa2LUD6XAG8=",
+        "rev": "ae584d90cbd0396a422289ee3efb1f1c9d141dc3",
+        "revCount": 713477,
         "type": "tarball",
-        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.710194%2Brev-f9f0d5c5380be0a599b1fb54641fa99af8281539/01938be8-64ce-75c6-94d4-dbc2e4d547fe/source.tar.gz"
+        "url": "https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.713477%2Brev-ae584d90cbd0396a422289ee3efb1f1c9d141dc3/01948db2-195e-7950-a428-9b0f77eccf99/source.tar.gz"
       },
       "original": {
         "type": "tarball",

--- a/flake.nix
+++ b/flake.nix
@@ -26,12 +26,12 @@
     in
     {
       closures = forAllSystems ({ system, ... }: nix.packages."${system}".default);
-      tarballs_indirect = forAllSystems ({ system, ... }: nix.checks."${system}".binaryTarball);
-      tarballs_direct = forAllSystems ({ system, ... }: "${nix.checks."${system}".binaryTarball}/nix-${nix.packages."${system}".default.version}-${system}.tar.xz");
+      tarballs_indirect = forAllSystems ({ system, ... }: nix.packages."${system}".binaryTarball);
+      tarballs_direct = forAllSystems ({ system, ... }: "${nix.packages."${system}".binaryTarball}/nix-${nix.packages."${system}".default.version}-${system}.tar.xz");
 
       checks = forAllSystems ({ system, ... }: {
         closure = nix.packages."${system}".default;
-        tarball = nix.checks."${system}".binaryTarball;
+        tarball = nix.packages."${system}".binaryTarball;
       });
 
       packages = forAllSystems ({ system, pkgs, ... }: {

--- a/flake.nix
+++ b/flake.nix
@@ -1,7 +1,7 @@
 {
   description = "Determinate Nix";
   inputs = {
-    nix.url = "https://flakehub.com/f/NixOS/nix/=2.25.3";
+    nix.url = "https://flakehub.com/f/NixOS/nix/=2.25.5";
     nixpkgs.url = "https://flakehub.com/f/NixOS/nixpkgs/*";
   };
 


### PR DESCRIPTION
This has the fix for https://github.com/NixOS/nix/issues/12248 that caused the revert of 2.25.4 in #39.

Flake lock file updates:

• Updated input 'nix':
    'https://api.flakehub.com/f/pinned/NixOS/nix/2.25.3/01938786-bc70-79e3-b7ee-bb61f8e7f238/source.tar.gz?narHash=sha256-T%2BwFMm3cj8pGJSwXmPuxG5pz%2B1gRDJoToF9OBxtzocA%3D' (2024-11-29)
  → 'https://api.flakehub.com/f/pinned/NixOS/nix/2.25.5/01948d59-c05d-738f-89bd-468dc7e6d7cb/source.tar.gz?narHash=sha256-9xrQhrqHCSqWsQveykZvG/ZMu0se66fUQw3xVSg6BpQ%3D' (2025-01-20)
• Updated input 'nixpkgs':
    'https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.710194%2Brev-f9f0d5c5380be0a599b1fb54641fa99af8281539/01938be8-64ce-75c6-94d4-dbc2e4d547fe/source.tar.gz?narHash=sha256-En%2BgSoVJ3iQKPDU1FHrR6zIxSLXKjzKY%2Bpnh9tt%2BYts%3D' (2024-12-02)
  → 'https://api.flakehub.com/f/pinned/NixOS/nixpkgs/0.2411.713477%2Brev-ae584d90cbd0396a422289ee3efb1f1c9d141dc3/01948db2-195e-7950-a428-9b0f77eccf99/source.tar.gz?narHash=sha256-e1WgPJpIYbOuokjgylcsuoEUCB4Jl2rQXa2LUD6XAG8%3D' (2025-01-20)