### PR TITLE
Remove nix-darwin option for enabling nix-daemon

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -96,8 +96,6 @@
             upgrade-nix-store-path-url = "https://install.determinate.systems/nix-upgrade/stable/universal";
           };
         };
-
-        services.nix-daemon.enable = true;
       };
 
       nixosModules.default = { lib, config, pkgs, ... }: {


### PR DESCRIPTION
The latest version of nix-darwin removed the `services.nix-daemon.enable` option.
See https://github.com/LnL7/nix-darwin/issues/1342