### PR TITLE
ci: only publish on "published" event

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -13,7 +13,7 @@ on:
       - labeled
   release:
     types:
-      - released
+      - published
 
 jobs:
   test-closures:


### PR DESCRIPTION
From our testing, this is the only event that triggers once-and-only-once per release.